### PR TITLE
Compressed OIS data now available

### DIFF
--- a/js/tji-datasets-explore.js
+++ b/js/tji-datasets-explore.js
@@ -241,7 +241,7 @@ TJIChartView.prototype.get_data = function() {
  * which we decompress here for convenient manipulation in this app.
  * 
  * Currently, the data is compressed by this script in our data-processing repo:
- * https://github.com/texas-justice-initiative/data-processing/blob/master/data_cleaning/create_compressed_cdr_for_website.ipynb 
+ * https://github.com/texas-justice-initiative/data-processing/blob/master/data_cleaning/create_compressed_data_for_website.ipynb 
  * 
  * See that file for an explanation of the compression and examples.
  */


### PR DESCRIPTION
This PR simply update documentation to reflect the newly complete file used to generate compressed OIS/CDR data, which lives in [our data-processing repo](https://github.com/texas-justice-initiative/data-processing/blob/master/data_cleaning/create_compressed_data_for_website.ipynb).

While that change fixes issue #24, this change updates the code documentation to reflect the new change.