### PR TITLE
Chart Colors

### DIFF
--- a/page-data.php
+++ b/page-data.php
@@ -44,11 +44,11 @@ get_header();
   jQuery(function(){
     var chartView = new TJIChartView({
       chart_configs: [
-        {type: 'bar',      group_by: 'year'},
+        {type: 'bar', group_by: 'year', sort_by: {column: 'key', direction: 'asc'}},
         {type: 'doughnut', group_by: 'race'},
         {type: 'doughnut', group_by: 'sex'},
         {type: 'doughnut', group_by: 'manner_of_death'},
-        {type: 'doughnut', group_by: 'age_group'},
+        {type: 'doughnut', group_by: 'age_group', sort_by: {column: 'key', direction: 'asc'}},
         {type: 'doughnut', group_by: 'type_of_custody'},
         {type: 'doughnut', group_by: 'death_location_type'},
         {type: 'doughnut', group_by: 'means_of_death'},

--- a/page-data.php
+++ b/page-data.php
@@ -44,7 +44,7 @@ get_header();
   jQuery(function(){
     var chartView = new TJIChartView({
       chart_configs: [
-        {type: 'bar', group_by: 'year', sort_by: {column: 'key', direction: 'asc'}},
+        {type: 'bar', group_by: 'year'},
         {type: 'doughnut', group_by: 'race'},
         {type: 'doughnut', group_by: 'sex'},
         {type: 'doughnut', group_by: 'manner_of_death'},


### PR DESCRIPTION
I took a stab at making the explore the data page less color crazy based on the feedback in our colors channel.
- sort chart groups by size so largest pie pieces have the same color across charts for page color coherency. The colors are set once and tied to a group label on initial data load, so as filters are selected, the largest pie piece's color will change -- but the labels + color for each pie piece will stay the same.
- do not change scale of bar chart as filters are selected.
![chartcolors](https://user-images.githubusercontent.com/3039125/42713978-ff792c7e-86b6-11e8-9344-9a908765d84f.gif)
