### PR TITLE
Fetch data from AWS links; add 2019 filter to Data Explore page

### DIFF
--- a/js/tji-datasets-explore.js
+++ b/js/tji-datasets-explore.js
@@ -326,6 +326,7 @@ var TJIChartView = function(props){
     $form: null,
     $charts_container: null,
     $summary_container: null,
+    $last_updated_date: null,
     $description: null,
     $select_dataset: null,
     $download: null,
@@ -684,6 +685,11 @@ TJIChartView.prototype.create_chartview_DOM = function() {
 
   _.each(this.datasets, function(dataset, index) {
     jQuery('<option value="'+index+'">'+dataset.name+'</option>').appendTo(that.ui.$select_dataset)
+  });
+
+  this.ui.$last_updated_date = jQuery('<div />', {
+    class: 'tji-chartview__last-updated-date',
+    html: ''
   });
 
   this.ui.$description = jQuery('<div />', {

--- a/page-data.php
+++ b/page-data.php
@@ -48,8 +48,8 @@ get_header();
         name: 'deaths in custody',
         description: "All deaths in custody in Texas since 2005, as reported to the Office of the Attorney General.",
         urls: {
-          compressed: '<?php echo get_template_directory_uri(); ?>/data/cdr_compressed.json',
-          full: '<?php echo get_template_directory_uri(); ?>/data/cdr_full.csv',
+          compressed: 'https://s3.amazonaws.com/tji-compressed-data/cdr_compressed.json',
+          full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/cleaned_custodial_death_reports.csv',
         },
         chart_configs: [
           {type: 'bar', group_by: 'year'},
@@ -77,8 +77,8 @@ get_header();
         name: 'civilians shot by officers',
         description: "Shootings involving Texas law enforcement since Sept. 2015, as reported to the Office of the Attorney General.",
         urls: {
-          compressed: '<?php echo get_template_directory_uri(); ?>/data/ois_compressed.json',
-          full: '<?php echo get_template_directory_uri(); ?>/data/ois_full.csv',
+          compressed: 'https://s3.amazonaws.com/tji-compressed-data/ois_compressed.json',
+          full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/shot_civilians.csv',
         },
         chart_configs: [
           {type: 'bar', group_by: 'year'},
@@ -100,8 +100,8 @@ get_header();
         name: 'OIS - officers shot by civilians',
         description: "Shootings that injured or killed Texas law enforcement officers since Sept. 2015, as reported to the Office of the Attorney General.",
         urls: {
-          compressed: '<?php echo get_template_directory_uri(); ?>/data/ois_officers_compressed.json',
-          full: '<?php echo get_template_directory_uri(); ?>/data/ois_officers_full.csv',
+          compressed: 'https://s3.amazonaws.com/tji-compressed-data/ois_officers_compressed.json',
+          full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/shot_officers.csv',
         },
         chart_configs: [
           {type: 'bar', group_by: 'year'},

--- a/template-parts/homepage-landing.php
+++ b/template-parts/homepage-landing.php
@@ -9,21 +9,21 @@
 
 <script type="text/javascript">
 	// Fetch JSON data for dynamic slider numbers
-	var fetch1 = jQuery.getJSON("<?php echo get_template_directory_uri(); ?>/data/cdr_compressed.json", function (cdrData) {
-		var cdrStartingYear = cdrData.meta.lookups.year[0];
-		var cdrTotalRecords = cdrData.meta.num_records;
+	var fetch1 = jQuery.getJSON("https://s3.amazonaws.com/tji-compressed-data/cdr_slider.json", function (cdrData) {
+		var cdrStartingYear = cdrData.startingYear;
+		var cdrTotalRecords = cdrData.totalRecords;
 		jQuery("#js-cdr-year").html(cdrStartingYear);
 		jQuery("#js-cdr-total").html(cdrTotalRecords.toLocaleString('en'));
 	});
-	var fetch2 = jQuery.getJSON("<?php echo get_template_directory_uri(); ?>/data/ois_compressed.json", function (oisData) {
-		var oisStartingYear = oisData.meta.lookups.year[0];
-		var oisTotalRecords = oisData.meta.num_records;
+	var fetch2 = jQuery.getJSON("https://s3.amazonaws.com/tji-compressed-data/ois_slider.json", function (oisData) {
+		var oisStartingYear = oisData.startingYear;
+		var oisTotalRecords = oisData.totalRecords;
 		jQuery("#js-ois-year").html(oisStartingYear);
 		jQuery("#js-ois-total").html(oisTotalRecords.toLocaleString('en'));
 	});
-	var fetch3 = jQuery.getJSON("<?php echo get_template_directory_uri(); ?>/data/ois_officers_compressed.json", function (officersData) {
-		var officersStartingYear = officersData.meta.lookups.year[0];
-		var officersTotalRecords = officersData.meta.num_records;
+	var fetch3 = jQuery.getJSON("https://s3.amazonaws.com/tji-compressed-data/ois_officers_slider.json", function (officersData) {
+		var officersStartingYear = officersData.startingYear;
+		var officersTotalRecords = officersData.totalRecords;
 		jQuery("#js-officers-year").html(officersStartingYear);
 		jQuery("#js-ois-officers-total").html(officersTotalRecords.toLocaleString('en'));
 	});

--- a/template-parts/homepage-landing.php
+++ b/template-parts/homepage-landing.php
@@ -9,29 +9,25 @@
 
 <script type="text/javascript">
 	// Fetch JSON data for dynamic slider numbers
-	var fetch1 = jQuery.getJSON("https://s3.amazonaws.com/tji-compressed-data/cdr_slider.json", function (cdrData) {
-		var cdrStartingYear = cdrData.startingYear;
-		var cdrTotalRecords = cdrData.totalRecords;
+	var fetchSliderData = jQuery.getJSON("https://s3.amazonaws.com/tji-compressed-data/all_slider_data.json", function(data) {
+		var cdrStartingYear = data.cdr.startingYear;
+		var cdrTotalRecords = data.cdr.totalRecords;
+		var oisStartingYear = data.ois.startingYear;
+	 	var oisTotalRecords = data.ois.totalRecords;
+	 	var officersStartingYear = data.ois_officers.startingYear;
+	 	var officersTotalRecords = data.ois_officers.totalRecords;
 		jQuery("#js-cdr-year").html(cdrStartingYear);
 		jQuery("#js-cdr-total").html(cdrTotalRecords.toLocaleString('en'));
-	});
-	var fetch2 = jQuery.getJSON("https://s3.amazonaws.com/tji-compressed-data/ois_slider.json", function (oisData) {
-		var oisStartingYear = oisData.startingYear;
-		var oisTotalRecords = oisData.totalRecords;
 		jQuery("#js-ois-year").html(oisStartingYear);
-		jQuery("#js-ois-total").html(oisTotalRecords.toLocaleString('en'));
-	});
-	var fetch3 = jQuery.getJSON("https://s3.amazonaws.com/tji-compressed-data/ois_officers_slider.json", function (officersData) {
-		var officersStartingYear = officersData.startingYear;
-		var officersTotalRecords = officersData.totalRecords;
-		jQuery("#js-officers-year").html(officersStartingYear);
-		jQuery("#js-ois-officers-total").html(officersTotalRecords.toLocaleString('en'));
+	 	jQuery("#js-ois-total").html(oisTotalRecords.toLocaleString('en'));
+	 	jQuery("#js-officers-year").html(officersStartingYear);
+	 	jQuery("#js-ois-officers-total").html(officersTotalRecords.toLocaleString('en'));
 	});
 
 	// If you use jQuery/Zepto in your site, then you can initialize it in any of your JS files, but make sure that you do it within document.ready event:
 	jQuery(document).ready(function () {
 		// Initialize Swiper Slider
-		jQuery.when(fetch1, fetch2, fetch3).done(function(){
+		jQuery.when(fetchSliderData).done(function(){
 			var mySwiper = new Swiper ('.swiper-container', {
 			  	loop:true,
 			  	centeredSlides: true,


### PR DESCRIPTION
- Fetch from new automated S3 links, rather than from the static files on our server.
- For homepage slider and data explore page

Fixes #126 #153 